### PR TITLE
added filler rules for MosesCompoundSplitter

### DIFF
--- a/src/edu/stanford/nlp/mt/process/MosesCompoundSplitter.java
+++ b/src/edu/stanford/nlp/mt/process/MosesCompoundSplitter.java
@@ -30,7 +30,7 @@ import edu.stanford.nlp.stats.Counter;
  */
 public class MosesCompoundSplitter {
   
-  private static String[] FILLERS = {"", "s", "es"};
+  private static String[] FILLERS = {"", "s", "es", "-", "en"};
   private static final int MIN_SIZE = 3; // the minimum number of characters is actually MIN_SIZE + 1
   private static final int MIN_COUNT = 5;
   private static final int MAX_COUNT = 5;
@@ -71,7 +71,7 @@ public class MosesCompoundSplitter {
         reader.close();
         throw new IOException("Illegal input in model file, line " + reader.getLineNumber() + ": " + line);
       }
-      int cnt = Integer.parseInt(input[2]);
+      long cnt = Long.parseLong(input[2]);
       totalCount += cnt;
       String tc = input[1];
       if(cnt < minCnt || tc.length() < MIN_SIZE + 1) continue; // these will never be used for splitting anyway

--- a/test/edu/stanford/nlp/mt/util/FlatNBestListTest.java
+++ b/test/edu/stanford/nlp/mt/util/FlatNBestListTest.java
@@ -50,7 +50,7 @@ public class FlatNBestListTest extends TestCase {
   }
 
   public void testToString() throws IOException {
-    String strRep = nbestList.toString();
+    String strRep = nbestList.toString().replaceAll("\r\n", "\n"); // replaceAll: fixes test on Windows platforms
     assertEquals(156305, strRep.length());
   }
 


### PR DESCRIPTION
test on De-En w/ a 12k test set shows improvement of 0.5% BLEU

this commit also fixes a unit test to make it pass on Windows