### PR TITLE
Identity translations

### DIFF
--- a/src/edu/stanford/nlp/mt/tm/DynamicTranslationModel.java
+++ b/src/edu/stanford/nlp/mt/tm/DynamicTranslationModel.java
@@ -282,6 +282,7 @@ public class DynamicTranslationModel<FV> implements TranslationModel<IString,FV>
     maxSourcePhrase = backgroundTM.maxSourcePhrase;
     maxTargetPhrase = backgroundTM.maxTargetPhrase;
     sampleSize = backgroundTM.sampleSize;
+    filterIncorrectNumeric = backgroundTM.filterIncorrectNumeric;
     if (backgroundTM.reorderingEnabled) {
       boolean doHierarchical = backgroundTM.lexModel instanceof HierarchicalReorderingModel;
       setReorderingScores(doHierarchical);
@@ -656,17 +657,10 @@ public class DynamicTranslationModel<FV> implements TranslationModel<IString,FV>
       }
     }
     
-    logger.info("all rules: " + concreteRules.toString());
-    
     // now handle additional phrase generators
     if(additionalPhraseGenerators != null) {
       for(TranslationModel<IString, FV> tm: additionalPhraseGenerators) {
         int bgSize = concreteRules.size();
-        
-        List<ConcreteRule<IString, FV>> rules = tm.getRules(source, sourceInputProperties, sourceInputId, scorer);
-        logger.info("rules added: " + rules.toString());
-        
-        
         concreteRules.addAll(tm.getRules(source, sourceInputProperties, sourceInputId, scorer));
         logger.info("input {}: adding {} rules from phrase generator {}", sourceInputId, concreteRules.size() - bgSize, tm.getName());
       }

--- a/src/edu/stanford/nlp/mt/tm/TranslationModelFactory.java
+++ b/src/edu/stanford/nlp/mt/tm/TranslationModelFactory.java
@@ -22,6 +22,7 @@ public class TranslationModelFactory {
   public static final String DYNAMIC_FEATURE_TEMPLATE = "dyn-feat";
   public static final String DYNAMIC_PHRASE_LENGTH = "dyn-plen";
   public static final String DYNAMIC_REORDERING = "dyn-reorder";
+  public static final String DYNAMIC_IDENTITY = "dyn-ident";
   public static final String SEPARATOR = ":";
 
   public static final String DYNAMIC_TAG = "dyn:";
@@ -42,6 +43,7 @@ public class TranslationModelFactory {
     // Parse options
     String featurePrefix = null;
     boolean setSystemIndex = true;
+    boolean addIdentityTranslations = false;
     int dynamicSampleSize = DynamicTranslationModel.DEFAULT_SAMPLE_SIZE;
     FeatureTemplate dynamicTemplate = FeatureTemplate.DENSE_EXT;
     int dynamicPhraseLength = DynamicTranslationModel.DEFAULT_MAX_PHRASE_LEN;
@@ -62,6 +64,8 @@ public class TranslationModelFactory {
         dynamicPhraseLength = Integer.valueOf(value);
       } else if (key.equalsIgnoreCase(DYNAMIC_REORDERING)) {
         reorderingType = value;
+      } else if (key.equals(DYNAMIC_IDENTITY)) {
+        addIdentityTranslations = Boolean.valueOf(value);
       } else {
         logger.warn("Unknown key/value pair: {}", option);
       }
@@ -82,6 +86,9 @@ public class TranslationModelFactory {
       if (reorderingType != null) {
         boolean doHierarchical = reorderingType.equals("hier");
         ((DynamicTranslationModel) translationModel).setReorderingScores(doHierarchical);
+      }
+      if (addIdentityTranslations) {
+        ((DynamicTranslationModel) translationModel).addPhraseGenerator(new IdentityPhraseGenerator());
       }
 
     } else {

--- a/src/edu/stanford/nlp/mt/tm/TranslationModelFactory.java
+++ b/src/edu/stanford/nlp/mt/tm/TranslationModelFactory.java
@@ -23,6 +23,7 @@ public class TranslationModelFactory {
   public static final String DYNAMIC_PHRASE_LENGTH = "dyn-plen";
   public static final String DYNAMIC_REORDERING = "dyn-reorder";
   public static final String DYNAMIC_IDENTITY = "dyn-ident";
+  public static final String DYNAMIC_FILTER_INCORRECT_NUMERIC = "dyn-filterIncorrectNumericPhrases";
   public static final String SEPARATOR = ":";
 
   public static final String DYNAMIC_TAG = "dyn:";
@@ -44,6 +45,7 @@ public class TranslationModelFactory {
     String featurePrefix = null;
     boolean setSystemIndex = true;
     boolean addIdentityTranslations = false;
+    boolean filterIncorrectNumeric = false;
     int dynamicSampleSize = DynamicTranslationModel.DEFAULT_SAMPLE_SIZE;
     FeatureTemplate dynamicTemplate = FeatureTemplate.DENSE_EXT;
     int dynamicPhraseLength = DynamicTranslationModel.DEFAULT_MAX_PHRASE_LEN;
@@ -66,6 +68,8 @@ public class TranslationModelFactory {
         reorderingType = value;
       } else if (key.equals(DYNAMIC_IDENTITY)) {
         addIdentityTranslations = Boolean.valueOf(value);
+      } else if (key.equals(DYNAMIC_FILTER_INCORRECT_NUMERIC)) {
+        filterIncorrectNumeric = Boolean.valueOf(value);
       } else {
         logger.warn("Unknown key/value pair: {}", option);
       }
@@ -90,6 +94,7 @@ public class TranslationModelFactory {
       if (addIdentityTranslations) {
         ((DynamicTranslationModel) translationModel).addPhraseGenerator(new IdentityPhraseGenerator());
       }
+      ((DynamicTranslationModel) translationModel).setFilterIncorrectNumeric(filterIncorrectNumeric);
 
     } else {
       translationModel = featurePrefix == null ? new CompiledPhraseTable<FV>(filename)

--- a/src/edu/stanford/nlp/mt/util/AbstractSequence.java
+++ b/src/edu/stanford/nlp/mt/util/AbstractSequence.java
@@ -127,6 +127,14 @@ abstract public class AbstractSequence<T> implements Sequence<T> {
     }
     return false;
   }
+  
+  @Override
+  public boolean contains(T element) {
+    for (int i = 0; i < size(); i++) {
+      if(get(i).equals(element)) return true;
+    }
+    return false;
+  }
 
   @Override
   public boolean startsWith(Sequence<T> prefix) {

--- a/src/edu/stanford/nlp/mt/util/Sequence.java
+++ b/src/edu/stanford/nlp/mt/util/Sequence.java
@@ -61,6 +61,14 @@ public interface Sequence<T> extends Iterable<T>, Comparable<Sequence<T>>, Seria
    * @return
    */
   public boolean contains(Sequence<T> subsequence);
+
+  /**
+   * True if this sequence contains the element. Otherwise, false.
+   * 
+   * @param element
+   * @return
+   */
+  public boolean contains(T element);
   
   /**
    * Convert to String with the specified delimiter.


### PR DESCRIPTION
The identity translations work. However,
1) they all receive a score of 0, so they are unlikely to be used
2) also punctuation is generated, e.g. ", -> ,"  or ". -> ."

As an alternative solution I have also implemented filtering out inadmissible numeric phrases. 

